### PR TITLE
Refactor EMA backtest test

### DIFF
--- a/test_backtest.py
+++ b/test_backtest.py
@@ -1,33 +1,74 @@
-#!/usr/bin/env python3
 import sys
-import traceback
+import os
+import pandas as pd
+import numpy as np
+from datetime import datetime, timedelta
+import pytest
+from unittest.mock import patch
 
-print("Starting EMA backtest test")
+# Ensure src package is on the path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-try:
-    print("Importing modules...")
-    from src.backtest.ema_backtest import run_ema_backtest
-    print("Imports successful")
-    
-    print("Running EMA backtest...")
-    results = run_ema_backtest(
-        symbol='BTC/USDT',
-        timeframe='1h',
-        days=10,
-        initial_balance=10000,
-        plot=True,
-        optimize=True
-    )
-    
-    print("\nBacktest Results:")
-    print(f"Total Return: {results['total_return']*100:.2f}%")
-    print(f"Win Rate: {results['win_rate']*100:.2f}%")
-    print(f"Profit Factor: {results.get('profit_factor', 0):.2f}")
-    print(f"Total Trades: {results['total_trades']}")
-    print(f"Fast EMA: {results['strategy_params']['fast_ema']}")
-    print(f"Slow EMA: {results['strategy_params']['slow_ema']}")
-    
-except Exception as e:
-    print(f"Error running EMA backtest: {type(e).__name__}: {str(e)}")
-    print("Traceback:")
-    traceback.print_exc(file=sys.stdout) 
+from src.backtest.ema_backtest import run_ema_backtest
+
+@pytest.fixture
+def sample_ohlcv():
+    """Provide simple OHLCV data for backtest."""
+    start = datetime.now() - timedelta(hours=50)
+    dates = pd.date_range(start=start, periods=50, freq="1h")
+    data = {
+        "open": 100 + np.arange(50, dtype=float),
+        "high": 101 + np.arange(50, dtype=float),
+        "low": 99 + np.arange(50, dtype=float),
+        "close": 100 + np.arange(50, dtype=float),
+        "volume": np.random.uniform(1, 10, size=50)
+    }
+    df = pd.DataFrame(data, index=dates)
+    return df
+
+
+def test_run_ema_backtest_returns_metrics(sample_ohlcv):
+    """Ensure run_ema_backtest outputs a metrics dictionary."""
+    with patch("src.backtest.ema_backtest.fetch_historical_data", return_value=sample_ohlcv), \
+         patch("src.backtest.ema_backtest._simulate_trades", return_value=([10000, 10050], [{'pnl': 50}])):
+        results = run_ema_backtest(
+            symbol="BTC/USDT",
+            timeframe="1h",
+            days=2,
+            initial_balance=10000.0,
+            plot=False,
+            optimize=False,
+        )
+
+    assert isinstance(results, dict)
+    expected_keys = [
+        "total_return",
+        "win_rate",
+        "sharpe_ratio",
+        "max_drawdown",
+        "total_trades",
+        "profit_factor",
+        "avg_win",
+        "avg_loss",
+        "equity_curve",
+        "strategy_params",
+    ]
+    for key in expected_keys:
+        assert key in results
+
+    numeric_keys = [
+        "total_return",
+        "win_rate",
+        "sharpe_ratio",
+        "max_drawdown",
+        "profit_factor",
+        "avg_win",
+        "avg_loss",
+    ]
+    for key in numeric_keys:
+        assert isinstance(results[key], (int, float))
+    assert isinstance(results["total_trades"], int)
+    assert isinstance(results["equity_curve"], list)
+    assert isinstance(results["strategy_params"], dict)
+    assert results["strategy_params"]["fast_ema"] is not None
+    assert results["strategy_params"]["slow_ema"] is not None


### PR DESCRIPTION
## Summary
- rewrite `test_backtest.py` as a proper pytest module
- patch heavy calls to run `run_ema_backtest` quickly
- verify expected metrics dictionary

## Testing
- `pytest test_backtest.py -q`
- `pytest -q` *(fails: test suite has existing failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841566b932c83279b41bbcd74c9f49d