### PR TITLE
Improve open_trade handling and config flags

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -41,6 +41,10 @@ VOL_RATIO_MIN = 1.2  # Optimal volume threshold from grid search
 VOLUME_THRESHOLD = 1.5  # Standard volume threshold
 ATR_PERIOD = 14  # Standard ATR period
 
+# Adaptive threshold settings
+USE_ADAPTIVE_THRESHOLDS = False  # Use percentile-based thresholds for RSI and volume
+ADAPTIVE_LOOKBACK = 100  # Lookback period for adaptive thresholds
+
 # Order execution settings
 ORDER_TIMEOUT_MS = 700  # Maker order timeout in milliseconds
 


### PR DESCRIPTION
## Summary
- add adaptive threshold settings to config
- default adaptive thresholds off
- update `ScalpingStrategy._open_trade` to accept price values directly
- guard market condition logging against missing data

## Testing
- `pytest -q` *(fails: KeyError: 'adaptive_volume_spike')*

------
https://chatgpt.com/codex/tasks/task_e_68415d50beb083279985bf8dfd8af37e