### PR TITLE
Add Bollinger breakout strategy

### DIFF
--- a/src/strategy/bollinger_breakout.py
+++ b/src/strategy/bollinger_breakout.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from .base_strategy import BaseStrategy
+from .confirm import add_bollinger_bands, is_bb_squeeze
+
+
+class BollingerBreakoutStrategy(BaseStrategy):
+    """Simple breakout strategy using Bollinger Band squeeze detection."""
+
+    def __init__(self, bb_period=20, bb_std=2, squeeze_lookback=20,
+                 squeeze_threshold=0.05, config=None):
+        super().__init__(config=config)
+        self.bb_period = bb_period
+        self.bb_std = bb_std
+        self.squeeze_lookback = squeeze_lookback
+        self.squeeze_threshold = squeeze_threshold
+
+    def apply_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Apply Bollinger Bands to the DataFrame."""
+        df = add_bollinger_bands(df, period=self.bb_period, std_dev=self.bb_std)
+        return df
+
+    def get_signal(self, df: pd.DataFrame) -> str:
+        """Return 'buy', 'sell' or '' based on breakout conditions."""
+        if df is None or len(df) < self.bb_period + 1:
+            return ''
+
+        df = self.apply_indicators(df.copy())
+        if not is_bb_squeeze(df, lookback=self.squeeze_lookback,
+                             squeeze_threshold=self.squeeze_threshold):
+            return ''
+
+        last = df.iloc[-1]
+        if last['close'] > last['bb_upper']:
+            return 'buy'
+        if last['close'] < last['bb_lower']:
+            return 'sell'
+        return ''

--- a/src/strategy/strategy_factory.py
+++ b/src/strategy/strategy_factory.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(
 from .ema_crossover import EMACrossoverStrategy
 from .base_strategy import BaseStrategy
 from src.strategy.rsi_strategy import RSIOscillatorStrategy
+from .bollinger_breakout import BollingerBreakoutStrategy
 from src.utils.health_monitor import StrategyHealthMonitor
 
 logger = logging.getLogger('trading_bot')
@@ -50,6 +51,7 @@ class StrategyFactory:
         self.strategies = {
             'ema_crossover': EMACrossoverStrategy,
             'rsi_oscillator': RSIOscillatorStrategy,
+            'bollinger_breakout': BollingerBreakoutStrategy,
         }
         
         # Discover other strategies in the strategy directory

--- a/tests/test_bollinger_breakout.py
+++ b/tests/test_bollinger_breakout.py
@@ -1,0 +1,41 @@
+import sys
+import os
+import pandas as pd
+from datetime import datetime, timedelta
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.strategy.bollinger_breakout import BollingerBreakoutStrategy
+
+
+def _create_df(last_close: float) -> pd.DataFrame:
+    dates = pd.date_range(datetime.now() - timedelta(minutes=20), periods=21, freq='1T')
+    data = {
+        'open': [100.0]*20 + [last_close],
+        'high': [100.0]*20 + [last_close],
+        'low': [100.0]*20 + [last_close],
+        'close': [100.0]*20 + [last_close],
+        'volume': [1.0]*21
+    }
+    return pd.DataFrame(data, index=dates)
+
+
+def test_buy_signal():
+    df = _create_df(101.0)
+    strat = BollingerBreakoutStrategy()
+    signal = strat.get_signal(df)
+    assert signal == 'buy'
+
+
+def test_sell_signal():
+    df = _create_df(99.0)
+    strat = BollingerBreakoutStrategy()
+    signal = strat.get_signal(df)
+    assert signal == 'sell'
+
+
+def test_no_signal_when_no_breakout():
+    df = _create_df(100.0)  # price within bands
+    strat = BollingerBreakoutStrategy()
+    signal = strat.get_signal(df)
+    assert signal == ''


### PR DESCRIPTION
## Summary
- implement simple Bollinger Band breakout strategy
- register strategy in factory
- test breakout signals

## Testing
- `pytest tests/test_bollinger_breakout.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68415bd727ac8327a4542629bd254d86